### PR TITLE
instantly kill gradle daemon in github workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,9 +36,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --no-daemon
     - uses: actions/upload-artifact@v2
       with:
         path: build/libs/*.jar
-    - name: Stop gradle daemons
-      run: ./gradlew --stop


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:disabling_the_daemon